### PR TITLE
Cache Coin Pricing Data from a Year before the Current Day

### DIFF
--- a/crypto-monitor/.gitignore
+++ b/crypto-monitor/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Secrets 
+.env

--- a/crypto-monitor/package-lock.json
+++ b/crypto-monitor/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.437.0",
+        "process": "^0.11.10",
         "react": "^18.3.1",
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.3.1",
@@ -3665,6 +3666,14 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/prop-types": {

--- a/crypto-monitor/package-lock.json
+++ b/crypto-monitor/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-slot": "^1.1.0",
         "@reduxjs/toolkit": "^2.2.7",
         "@rtk-query/codegen-openapi": "^1.2.0",
+        "@upstash/redis": "^1.34.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.437.0",
@@ -1703,6 +1704,14 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@upstash/redis": {
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.34.0.tgz",
+      "integrity": "sha512-TrXNoJLkysIl8SBc4u9bNnyoFYoILpCcFJcLyWCccb/QSUmaVKdvY0m5diZqc3btExsapcMbaw/s/wh9Sf1pJw==",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.1",
       "dev": true,
@@ -2101,6 +2110,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/css-box-model": {
       "version": "1.2.1",

--- a/crypto-monitor/package.json
+++ b/crypto-monitor/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@reduxjs/toolkit": "^2.2.7",
     "@rtk-query/codegen-openapi": "^1.2.0",
+    "@upstash/redis": "^1.34.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.437.0",

--- a/crypto-monitor/package.json
+++ b/crypto-monitor/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.437.0",
+    "process": "^0.11.10",
     "react": "^18.3.1",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.3.1",

--- a/crypto-monitor/src/components/LiveChart.tsx
+++ b/crypto-monitor/src/components/LiveChart.tsx
@@ -42,7 +42,7 @@ export const LiveChart = ({ id, vsCurrency, days, onError }: LiveChartProps) => 
         }
     }) || [];
 
-    const dataPoints = [...historicalDataPoints, ...liveDataPoints];
+    const dataPoints = [...historicalDataPoints.slice(0, -1), ...liveDataPoints];
 
     if (isError) {
         onError(id);

--- a/crypto-monitor/src/lib/utils.ts
+++ b/crypto-monitor/src/lib/utils.ts
@@ -8,3 +8,16 @@ export function cn(...inputs: ClassValue[]) {
 export function toDateWithoutTime(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
+
+export function getDateOneYearBefore(date: Date): Date {
+  const oneYearBefore = new Date(date);
+  oneYearBefore.setFullYear(date.getFullYear() - 1);
+  return oneYearBefore;
+}
+
+export const getCacheKey = (coinId: string) => {
+  const today = toDateWithoutTime(new Date());
+  const oneYearBefore = getDateOneYearBefore(today);
+
+  return `${coinId}-${oneYearBefore.getTime()}-${today.getTime()}`;
+}

--- a/crypto-monitor/src/lib/utils.ts
+++ b/crypto-monitor/src/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function toDateWithoutTime(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}

--- a/crypto-monitor/src/store/coinGeckoApi.ts
+++ b/crypto-monitor/src/store/coinGeckoApi.ts
@@ -1,7 +1,6 @@
+import { getCacheKey } from "@/lib/utils";
 import { baseApi } from "./baseApi";
 import { Redis } from "@upstash/redis";
-
-console.log("Redis URL: ", import.meta.env.VITE_UPSTASH_REDIS_REST_URL);
 
 const redis = new Redis({
   url: import.meta.env.VITE_UPSTASH_REDIS_REST_URL,
@@ -171,15 +170,38 @@ const injectedRtkApi = baseApi
         GetCoinsByIdMarketChartApiResponse,
         GetCoinsByIdMarketChartApiArg
       >({
-        query: (queryArg) => ({
-          url: `/coins/${queryArg.id}/market_chart`,
-          params: {
-            vs_currency: queryArg.vsCurrency,
-            days: queryArg.days,
-            interval: queryArg.interval,
-            precision: queryArg.precision,
-          },
-        }),
+        queryFn: async (arg, _api, _extraOptions, baseQuery) => {
+          const cacheKey = getCacheKey(arg.id);
+          const cachedData = await redis.get(cacheKey);
+
+          if (cachedData) {
+            return { data: cachedData as GetCoinsByIdMarketChartApiResponse };
+          }
+
+          const fetchedData = await baseQuery({
+            url: `/coins/${arg.id}/market_chart`,
+            params: {
+              vs_currency: arg.vsCurrency,
+              days: arg.days,
+              interval: arg.interval,
+              precision: arg.precision,
+            },
+          });
+
+          if (fetchedData.error) {
+            return {
+              error: fetchedData.error,
+            }
+          }
+
+          if (fetchedData.data) {
+            redis.set(cacheKey, fetchedData.data, { ex: 86400 });
+          }
+
+          return {
+            data: fetchedData.data as GetCoinsByIdMarketChartApiResponse,
+          }
+        },
         providesTags: ["coins"],
       }),
       getCoinsByIdMarketChartRange: build.query<

--- a/crypto-monitor/src/store/coinGeckoApi.ts
+++ b/crypto-monitor/src/store/coinGeckoApi.ts
@@ -8,7 +8,7 @@ const redis = new Redis({
 });
 
 const UNIX_TO_CURRENT_TIME_MILLIS = 1000;
-
+  
 export const addTagTypes = [
   "ping",
   "simple",

--- a/crypto-monitor/src/store/coinGeckoApi.ts
+++ b/crypto-monitor/src/store/coinGeckoApi.ts
@@ -1,4 +1,12 @@
 import { baseApi } from "./baseApi";
+import { Redis } from "@upstash/redis";
+
+console.log("Redis URL: ", import.meta.env.VITE_UPSTASH_REDIS_REST_URL);
+
+const redis = new Redis({
+  url: import.meta.env.VITE_UPSTASH_REDIS_REST_URL,
+  token: import.meta.env.VITE_UPSTASH_REDIS_REST_TOKEN,
+});
 
 const UNIX_TO_CURRENT_TIME_MILLIS = 1000;
 

--- a/crypto-monitor/src/store/coinGeckoApi.ts
+++ b/crypto-monitor/src/store/coinGeckoApi.ts
@@ -1,5 +1,7 @@
 import { getCacheKey } from "@/lib/utils";
 import { baseApi } from "./baseApi";
+
+// Cloudflare import works across all Hosting Providers (ex: Vercel, Netlify, Cloudflare)
 import { Redis } from "@upstash/redis/cloudflare";
 
 const redis = new Redis({

--- a/crypto-monitor/src/store/coinGeckoApi.ts
+++ b/crypto-monitor/src/store/coinGeckoApi.ts
@@ -1,6 +1,6 @@
 import { getCacheKey } from "@/lib/utils";
 import { baseApi } from "./baseApi";
-import { Redis } from "@upstash/redis";
+import { Redis } from "@upstash/redis/cloudflare";
 
 const redis = new Redis({
   url: import.meta.env.VITE_UPSTASH_REDIS_REST_URL,

--- a/crypto-monitor/vercel.json
+++ b/crypto-monitor/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/crypto-monitor/vite.config.ts
+++ b/crypto-monitor/vite.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(() => {
   // const env = loadEnv(mode, process.cwd(), '');
   return {
     plugins: [react()],

--- a/crypto-monitor/vite.config.ts
+++ b/crypto-monitor/vite.config.ts
@@ -6,7 +6,10 @@ import path from 'path'
 export default defineConfig({
   plugins: [react()],
   define: {
-    'process.env': {},
+    'process.env': {
+      VITE_UPSTASH_REDIS_REST_URL: process.env.VITE_UPSTASH_REDIS_REST_URL,
+      VITE_UPSTASH_REDIS_REST_TOKEN: process.env.VITE_UPSTASH_REDIS_REST_TOKEN,
+    },
   },
   resolve: {
     alias: {

--- a/crypto-monitor/vite.config.ts
+++ b/crypto-monitor/vite.config.ts
@@ -1,19 +1,20 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  define: {
-    'process.env': {
-      VITE_UPSTASH_REDIS_REST_URL: process.env.VITE_UPSTASH_REDIS_REST_URL,
-      VITE_UPSTASH_REDIS_REST_TOKEN: process.env.VITE_UPSTASH_REDIS_REST_TOKEN,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    define: {
+      'process.env': env,
     },
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-})
+  };
+});

--- a/crypto-monitor/vite.config.ts
+++ b/crypto-monitor/vite.config.ts
@@ -5,6 +5,9 @@ import path from 'path'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'process.env': {},
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/crypto-monitor/vite.config.ts
+++ b/crypto-monitor/vite.config.ts
@@ -5,11 +5,11 @@ import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '');
+  // const env = loadEnv(mode, process.cwd(), '');
   return {
     plugins: [react()],
     define: {
-      'process.env': env,
+      'process.env': process.env,
     },
     resolve: {
       alias: {


### PR DESCRIPTION
This significantly reduces the number of daily calls to the CoinGecko API for Historical Pricing data across multiple CryptoCurrencies

Data is cached and retrieved from a Redis Cache hosted on Upstash